### PR TITLE
Block fusion components

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When you have a fusable joker, pressing on it will show a **"fuse" button**. Whe
 
 <img width=500px src="art/jokers_tab.png?raw=true" alt="Showcase of jokers tab 5"></a>
 
-The are a total of 15 fusions added in the mod, with more coming in the future!
+There are a total of 15 fusions added in the mod!
 
 You can find a list of their abilities, as well as the jokers needed to make them, in this link: https://itayfeder.github.io/Fusion-Jokers/
 
@@ -51,4 +51,5 @@ Developers can call the function `FusionJokers.fusions:add_fusion()` to register
 
 ## 🎉 Credits <a name = "credits"></a>
 
-- The mod was written by [**Itayfeder**](https://github.com/stars/itayfeder/lists/balatro-modding), with art created by [**Lyman**](https://github.com/spikeof2010)
+- The original mod was written by [**Itayfeder**](https://github.com/stars/itayfeder/lists/balatro-modding), with art created by [**Lyman**](https://github.com/spikeof2010)
+- [**elbe**](https://github.com/lshtech) did several patches to handle breaking changes in Steamodded, as well as various other features

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 - [About](#about)
 - [How to Download](#how_to_download)
+- [Config](#config)
 - [Fusion API (For Developers)](#fusion_api)
 - [Credits](#credits)
 
@@ -42,6 +43,10 @@ You can find a list of their abilities, as well as the jokers needed to make the
 - The mod requires Steamodded. You can see info about how to use it [here](https://github.com/Steamopollys/Steamodded)
 - Download the latest release of Fusion Jokers
 - Extract the downloaded mod to the Mods folder (at %appdata%/Balatro/Mods)
+
+## ⚙️ Config <a name = "config"></a>
+
+- '''Block used components from reappearing''': Jokers used in a fusion cannot reappear if the fusion is present. Currently only applies to Fusion Jokers fusions; cross-mod functionality is planned. Default true.
 
 ## ➕ Fusion API (For Developers) <a name = "fusion_api"></a>
 

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -81,6 +81,23 @@ FusionJokers.fusions = {
 	}, result_joker = "j_camping_trip", cost = 10 },
 }
 
+for _, fusion in ipairs(FusionJokers.fusions) do
+    local fused = fusion.result_joker
+
+    for _, component in ipairs(fusion.jokers) do
+        local component_name = component.name
+
+        SMODS.Joker:take_ownership(component_name, {
+            in_pool = function(self, args)
+                if #SMODS.find_card('j_showman') > 0 then return true end -- Allow finding copies if Showman is present
+                if #SMODS.find_card(fused) > 0 then return false end -- If the fused Joker exists, remove both components
+                return true
+            end
+        }, true) -- silent | suppresses mod badge
+    end
+end
+
+
 local rarity = SMODS.Rarity{
 	key = "fusion",
 	loc_txt = {

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -750,7 +750,7 @@ function SMODS.INIT.FusionJokers()
 
 	function SMODS.Jokers.j_dynamic_duo.calculate(card, context)
 		if context.individual and context.cardarea == G.play and
-		not context.other_card:is_face() then
+		not context.other_card:is_face() and not SMODS.has_no_rank(context.other_card) then
 			return {
 				mult = card.ability.extra.mult,
 				chips = card.ability.extra.chips,

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -93,6 +93,7 @@ for _, fusion in ipairs(FusionJokers.fusions) do
         SMODS.Joker:take_ownership(component_name, {
             in_pool = function(self, args)
                 if #SMODS.find_card('j_showman') > 0 then return true end -- Allow finding copies if Showman is present
+				if not FusionJokers.fusionconfig.block_components then return true end --If the option is disabled, don't do the check
                 if #SMODS.find_card(fused) > 0 then return false end -- If the fused Joker exists, remove both components
                 return true
             end

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -714,7 +714,7 @@ function SMODS.INIT.FusionJokers()
 	end
 
 	function SMODS.Jokers.j_big_bang.calculate(card, context)
-		if context.cardarea == G.jokers and not context.after and not context.before and context.scoring_name then
+		if context.cardarea == G.jokers and context.joker_main and context.scoring_name then
 			local mult_val = 1 + card.ability.extra.Xmult * (G.GAME.hands[context.scoring_name].level + G.GAME.hands[context.scoring_name].played)
 			return {
 				message = localize{type='variable',key='a_xmult',vars={mult_val}},
@@ -791,7 +791,7 @@ function SMODS.INIT.FusionJokers()
              end)}))
 		end
 
-		if context.cardarea == G.jokers and card.ability.mult > 0 and not context.after and not context.before then
+		if context.cardarea == G.jokers and card.ability.mult > 0 and context.joker_main then
 			return {
 				message = localize{type='variable',key='a_mult',vars={card.ability.mult}},
 				mult_mod = card.ability.mult
@@ -888,7 +888,7 @@ function SMODS.INIT.FusionJokers()
 			
 		end
 
-		if context.cardarea == G.jokers and not context.after and not context.before then
+		if context.cardarea == G.jokers and context.joker_main then
 			if card.ability.extra.side == "mult" then
 				return {
 					message = localize{type='variable',key='a_mult',vars={card.ability.extra.mult}},
@@ -994,7 +994,7 @@ function SMODS.INIT.FusionJokers()
 			end
 		end
 
-		if context.cardarea == G.jokers and not context.after and not context.before then
+		if context.cardarea == G.jokers and context.joker_main then
 			local x = 0
 			for i = 1, #G.jokers.cards do
 				if G.jokers.cards[i].ability.set == 'Joker' then x = x + 1 end
@@ -1091,7 +1091,7 @@ function SMODS.INIT.FusionJokers()
 			end
 		end
 
-		if context.cardarea == G.jokers and not context.after and not context.before then
+		if context.cardarea == G.jokers and context.joker_main then
 			local mult = card.ability.mult * G.GAME.current_round.discards_left
 			return {
 				message = localize{type='variable',key='a_mult',vars={mult}},
@@ -1184,7 +1184,7 @@ function SMODS.INIT.FusionJokers()
 			end
 		end
 
-		if context.cardarea == G.jokers and not context.before and not context.after then
+		if context.cardarea == G.jokers and context.joker_main then
 			return {
 				message = localize{type='variable',key='a_xmult',vars={card.ability.extra.total}},
 				Xmult_mod = card.ability.extra.total

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -6,6 +6,7 @@
 --- BADGE_COLOUR: B26CBB
 --- PRIORITY: -10000
 --- PREFIX: fuse
+--- DEPENDENCIES: [Steamodded>=1.0.0~ALPHA-1307d]
 --- CONFLICTS: [Talisman<=2.0]
 ----------------------------------------------
 ------------MOD CODE -------------------------

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -81,6 +81,9 @@ FusionJokers.fusions = {
 	}, result_joker = "j_camping_trip", cost = 10 },
 }
 
+FusionJokers.fusionconfig = SMODS.current_mod.config
+SMODS.load_file('configui.lua')()
+
 for _, fusion in ipairs(FusionJokers.fusions) do
     local fused = fusion.result_joker
 

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -117,6 +117,10 @@ local to_number = to_number or function(num)
 	return num
 end
 
+local to_big = to_big or function(num)
+	return num
+end
+
 local function has_joker(val, start_pos)
 	if not start_pos then
 		start_pos = 0
@@ -545,11 +549,11 @@ function SMODS.INIT.FusionJokers()
 	function SMODS.Jokers.j_diamond_bard.calculate(card, context)
 		if context.individual and context.cardarea == G.play and
 		context.other_card:is_suit('Diamonds') then
-			G.GAME.dollar_buffer = (G.GAME.dollar_buffer or 0) + card.ability.extra.money
+			G.GAME.dollar_buffer = (G.GAME.dollar_buffer or 0) + to_big(card.ability.extra.money)
 			G.E_MANAGER:add_event(Event({func = (function() G.GAME.dollar_buffer = 0; return true end)}))
 			return {
 				dollars = card.ability.extra.money,
-				mult = card.ability.extra.mult * (1 + math.floor(G.GAME.dollars / card.ability.extra.money_threshold)),
+				mult = card.ability.extra.mult * (1 + math.floor(to_number(G.GAME.dollars) / card.ability.extra.money_threshold)),
 				card = card
 			}
 		end

--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -6,6 +6,7 @@
 --- BADGE_COLOUR: B26CBB
 --- PRIORITY: -10000
 --- PREFIX: fuse
+--- CONFLICTS: [Talisman<=2.0]
 ----------------------------------------------
 ------------MOD CODE -------------------------
 

--- a/mod/config.lua
+++ b/mod/config.lua
@@ -1,0 +1,3 @@
+return {
+    ["block_components"] = true,
+}

--- a/mod/configui.lua
+++ b/mod/configui.lua
@@ -1,0 +1,11 @@
+SMODS.current_mod.config_tab = function()
+    return {n = G.UIT.ROOT, config = {r = 0.1, minw = 8, minh = 6, align = "tl", padding = 0.2, colour = G.C.BLACK}, nodes = {
+        {n = G.UIT.C, config = {minw=1, minh=1, align = "tl", colour = G.C.CLEAR, padding = 0.15}, nodes = {
+        create_toggle({
+            label = "Block used components from reappearing",
+            ref_table = FusionJokers.fusionconfig,
+            ref_value = 'block_components',
+        }),
+        }}
+    }}
+end


### PR DESCRIPTION
Adds a function to block fusion components from appearing if their fused Joker is present; e.g. if Diamond Bard is present then Greedy Joker and Rough Gem can't appear again.

~~this is supposed to be an entirely separate pr from the various fixes but apparently i don't know how to do that~~

e: There's a config option now too